### PR TITLE
update rest-client https://github.com/rest-client/rest-client/issues/612

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,19 +2,19 @@ GEM
   remote: https://rubygems.org/
   specs:
     daemons (1.2.4)
-    domain_name (0.5.20160826)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     eventmachine (1.2.0.1)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
-    mime-types (3.1)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2018.0812)
     netrc (0.11.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
-    rest-client (2.0.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -29,7 +29,7 @@ GEM
     tilt (2.0.5)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.5)
 
 PLATFORMS
   ruby
@@ -40,4 +40,4 @@ DEPENDENCIES
   thin
 
 BUNDLED WITH
-   1.12.5
+   1.16.6


### PR DESCRIPTION
```
app web.1 - - 2019-01-03 20:13:06 - KeyError - key not found: :ciphers:
app web.1 - - /app/vendor/bundle/ruby/2.4.0/gems/rest-client-2.0.0/lib/restclient/request.rb:198:in `fetch'
app web.1 - - /app/vendor/bundle/ruby/2.4.0/gems/rest-client-2.0.0/lib/restclient/request.rb:198:in `initialize'
app web.1 - - /app/vendor/bundle/ruby/2.4.0/gems/rest-client-2.0.0/lib/restclient/request.rb:52:in `new'
app web.1 - - /app/vendor/bundle/ruby/2.4.0/gems/rest-client-2.0.0/lib/restclient/request.rb:52:in `execute'
app web.1 - - /app/vendor/bundle/ruby/2.4.0/gems/rest-client-2.0.0/lib/restclient.rb:71:in `post'
app web.1 - - config.ru:18:in `block in <class:SlackStatuspageApp>'
```

Was getting this error https://github.com/rest-client/rest-client/issues/612 when running the app recently. Updated gem lockfile as it seems rest-client had a fix from 2.0.0 to 2.0.1 that resolved it.