### PR TITLE
Slack Friendly Formatting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,4 +40,4 @@ DEPENDENCIES
   thin
 
 BUNDLED WITH
-   1.16.6
+   2.1.4

--- a/block_utils.rb
+++ b/block_utils.rb
@@ -1,0 +1,20 @@
+require 'time'
+
+  def build_title_block(title, link, timestamp)
+    return { type: "section", text: { type: "mrkdwn", text: "<#{link}|#{title}>\n#{timestamp}" }}
+  end
+  
+  def build_update_block(update_hash)
+    status = update_hash["status"]
+    timestamp = format_time(update_hash["updated_at"])
+    description = update_hash["body"]
+    return { type: "section", text: { type: "mrkdwn", text: "*#{status}*\n#{timestamp}\n#{description}"}}
+  end
+
+  def build_divider_block()
+    return {type: "divider"}
+  end
+  
+  def format_time(timestamp)
+    return Time.parse(timestamp).strftime("%b %-d %H:%M %Z")
+  end

--- a/block_utils.rb
+++ b/block_utils.rb
@@ -1,7 +1,7 @@
 require 'time'
 
   def build_title_block(title, link, timestamp)
-    return { type: "section", text: { type: "mrkdwn", text: "<#{link}|#{title}>\n#{timestamp}" }}
+    return { type: "section", text: { type: "mrkdwn", text: ":triangular_flag_on_post:\n<#{link}|#{title}>\n#{timestamp}" }}
   end
   
   def build_update_block(update_hash)

--- a/block_utils.rb
+++ b/block_utils.rb
@@ -1,7 +1,7 @@
 require 'time'
 
   def build_title_block(title, link, timestamp)
-    return { type: "section", text: { type: "mrkdwn", text: ":triangular_flag_on_post:\n<#{link}|#{title}>\n#{timestamp}" }}
+    return { type: "section", text: { type: "mrkdwn", text: ":triangular_flag_on_post:\n<#{link}|#{title}> (#{timestamp})" }}
   end
   
   def build_update_block(update_hash)

--- a/config.ru
+++ b/config.ru
@@ -16,23 +16,25 @@ class SlackStatuspageApp < Sinatra::Base
     params[:splat].first
   end
   post "/*" do
-    block_array = []
     statuspage = JSON.parse(request.body.read)
-    
-    incident = statuspage["incident"]
-    title = incident["name"]
-    titleurl = incident["shortlink"]
-    timestamp = format_time(incident["started_at"])
+    if(!statuspage.has_key?("incident_updates")){
 
-    block_array.push(build_title_block(title, titleurl, timestamp))
-
-    updates = incident["incident_updates"]
-
-    block_array.push(build_divider_block())
-    block_array.push(build_update_block(updates.first))
-
-    slack = {text: "Status Page Update", blocks: block_array}
-    RestClient.post("https://hooks.slack.com/#{params[:splat].first}", payload: slack.to_json)
+      incident = statuspage["incident"]
+      title = incident["name"]
+      titleurl = incident["shortlink"]
+      timestamp = format_time(incident["started_at"])
+      
+      block_array = []
+      block_array.push(build_title_block(title, titleurl, timestamp))
+      
+      updates = incident["incident_updates"]
+      
+      block_array.push(build_divider_block())
+      block_array.push(build_update_block(updates.first))
+      
+      slack = {text: "Status Page Update", blocks: block_array}
+      RestClient.post("https://hooks.slack.com/#{params[:splat].first}", payload: slack.to_json)
+    }
 
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -24,11 +24,13 @@ class SlackStatuspageApp < Sinatra::Base
     titleurl = incident["shortlink"]
     timestamp = format_time(incident["started_at"])
 
+    block_array.push(build_divider_block())
+    block_array.push(build_divider_block())
     block_array.push(build_title_block(title, titleurl, timestamp))
 
     updates = incident["incident_updates"]
 
-    block_array.push(build_divider_block)
+    block_array.push(build_divider_block())
     block_array.push(build_update_block(updates.first))
 
     slack = {text: "Gov Notify Status Update", blocks: block_array}

--- a/config.ru
+++ b/config.ru
@@ -28,10 +28,9 @@ class SlackStatuspageApp < Sinatra::Base
 
     updates = incident["incident_updates"]
 
-    updates.each { |update_hash|
-      block_array.push(build_divider_block)
-      block_array.push(build_update_block(update_hash))
-    }
+    block_array.push(build_divider_block)
+    block_array.push(build_update_block(updates.first))
+
     slack = {text: "Gov Notify Status Update", blocks: block_array}
     RestClient.post("https://hooks.slack.com/#{params[:splat].first}", payload: slack.to_json)
 

--- a/config.ru
+++ b/config.ru
@@ -31,7 +31,7 @@ class SlackStatuspageApp < Sinatra::Base
     block_array.push(build_divider_block())
     block_array.push(build_update_block(updates.first))
 
-    slack = {text: "Status Page Update :information_source:", blocks: block_array}
+    slack = {text: "Status Page Update", blocks: block_array}
     RestClient.post("https://hooks.slack.com/#{params[:splat].first}", payload: slack.to_json)
 
   end

--- a/config.ru
+++ b/config.ru
@@ -3,18 +3,69 @@ require 'bundler/setup'
 require 'sinatra/base'
 require 'rest-client'
 require 'json'
+require 'time'
 
 # For documentation on incoming webhooks see
 # https://help.statuspage.io/knowledge_base/topics/webhook-notifications
 # and scroll down to Incident Updates
+
+def build_title_block(title, link, timestamp)
+  block = <<~END
+  {
+    "type": "section",
+    "text": {
+      "type": "mrkdwn",
+      "text": "[#{title}](#{link})\\n
+               #{timestamp}"
+    }
+  }
+  END
+  return block
+
+def build_update_block(update_hash)
+  status = update_hash["status"]
+  timestamp = update_hash["updated_at"]
+  description = update_hash["body"]
+
+  block = <<~END
+  {
+    "type": "divider"
+  },
+  {
+    "type": "section",
+    "text": {
+      "type": "mrkdwn",
+      "text": "**#{status}**\\n
+               #{timestamp}\\n
+               #{description}"
+    }
+  }
+  END
+
+def format_time(timestamp)
+  return Time.parse(timestamp).strftime("%b %-d %H:%M %Z")
 
 class SlackStatuspageApp < Sinatra::Base
   get "/*" do
     params[:splat].first
   end
   post "/*" do
-    #statuspage = JSON.parse(request.body.read)
-    slack = {text: request.body.read}
+    block_array = []
+    statuspage = JSON.parse(request.body.read)
+    
+    incident = statuspage["incident"]
+    title = incident["name"]
+    titleurl = incident["shortlink"]
+    timestamp = format_time(incident["started_at"])
+
+    block_array.push(build_title_block(title, titleurl, timestamp))
+
+    updates = statuspage["incident_updates"]
+    updates.each { |update_hash|
+      block_array.push(build_update_block(update_hash))
+    }
+
+    slack = {"blocks": block_array}
     RestClient.post("https://hooks.slack.com/#{params[:splat].first}", payload: slack.to_json)
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -24,8 +24,6 @@ class SlackStatuspageApp < Sinatra::Base
     titleurl = incident["shortlink"]
     timestamp = format_time(incident["started_at"])
 
-    block_array.push(build_divider_block())
-    block_array.push(build_divider_block())
     block_array.push(build_title_block(title, titleurl, timestamp))
 
     updates = incident["incident_updates"]

--- a/config.ru
+++ b/config.ru
@@ -31,7 +31,7 @@ class SlackStatuspageApp < Sinatra::Base
     block_array.push(build_divider_block())
     block_array.push(build_update_block(updates.first))
 
-    slack = {text: "Gov Notify Status Update", blocks: block_array}
+    slack = {text: "Status Page Update :information_source:", blocks: block_array}
     RestClient.post("https://hooks.slack.com/#{params[:splat].first}", payload: slack.to_json)
 
   end


### PR DESCRIPTION
Status Page offers an RSS feature to automatically post updates to a slack channel. Whilst these are nicely formatted, they also have high latency and sometimes arrive half an hour after the status page update is made. tdmalone's statuspage-to-slack server receives webhook notifications from statuspage and forwards it on to slack webhooks. This PR extends that server by formatting statuspage posts into a slack friendly format mirroring the RSS posts, before sending it on to the slack webhook. This allows us to have nicely formatted and prompt updates in slack